### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,6 +47,8 @@ jobs:
 
   dependency-review:
     name: Dependency Review
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 


### PR DESCRIPTION
Potential fix for [https://github.com/kennycyb/my-web-tools/security/code-scanning/4](https://github.com/kennycyb/my-web-tools/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the `dependency-review` job in `.github/workflows/security.yml`. The minimal required permission for this job is `contents: read`, as the `actions/dependency-review-action` only needs to read repository contents and does not require write access. This change should be made directly under the `dependency-review` job definition (after `name:` and before `runs-on:`), ensuring that the GITHUB_TOKEN used by this job is limited to read-only access to repository contents. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
