### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   security-audit:
     name: Security Audit
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/kennycyb/my-web-tools/security/code-scanning/1](https://github.com/kennycyb/my-web-tools/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the `security-audit` job in `.github/workflows/security.yml`. This block should grant only the minimal permissions required for the job to function. Based on the steps in the job, the main requirements are reading repository contents and uploading SARIF files. The minimal starting point recommended by CodeQL is `contents: read`. If uploading SARIF files requires additional permissions (such as `security-events: write`), we should include those as well. The change should be made by inserting a `permissions` block under the `security-audit` job, ideally after the `name` field and before `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
