### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     name: Test and Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/kennycyb/my-web-tools/security/code-scanning/2](https://github.com/kennycyb/my-web-tools/security/code-scanning/2)

To fix the problem, we should add an explicit `permissions` block to the `test` job (or at the workflow root, but per the warning, the job is highlighted). The minimal required permission for a job that only checks out code and runs tests/lints is `contents: read`. This change should be made by adding the following block under the `test` job definition (at the same indentation as `runs-on`):

```yaml
permissions:
  contents: read
```

No other changes are needed, and this will not affect the existing functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
