### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     name: Build Application
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/kennycyb/my-web-tools/security/code-scanning/3](https://github.com/kennycyb/my-web-tools/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the `build` job in `.github/workflows/ci.yml`. This block should specify the least privilege required for the job to function correctly. Since the `build` job only checks out code, installs dependencies, builds the application, and uploads artifacts, it does not need write access to the repository. The minimal required permission is `contents: read`. You should add the following block under the `build` job, at the same indentation level as `runs-on` and `needs`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed. The change is limited to the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
